### PR TITLE
Allow cache

### DIFF
--- a/example/foo_bisector.py
+++ b/example/foo_bisector.py
@@ -6,7 +6,7 @@ from example.foo import foo
 
 
 class FooBisector(GitBisector):
-    def get_output(self) -> str:
+    def get_output(self, cache_dir: Optiona[str] = None) -> str:
         return foo()
 
     def are_outputs_identical(self, output1: str, output2: str) -> bool:

--- a/gitbi/git_bisector.py
+++ b/gitbi/git_bisector.py
@@ -132,6 +132,9 @@ class GitBisector(ABC):
                 subprocess.run(['git', 'bisect', 'bad', end_commit], check=True)
                 
                 for _ in range(MAX_ITERATIONS):
+                    # Get output for current commit
+                    current_output = self.get_example_in_subprocess(main_name, main_content, cache_dir)
+
                     # Compare outputs
                     if self.are_outputs_identical(baseline_output, current_output):
                         # Output is the same, continue bisecting


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced optional caching functionality for output retrieval in the `FooBisector` and `GitBisector` classes.
	- Added a command-line option `--cache-dir` for specifying a caching directory during example execution.

- **Bug Fixes**
	- Enhanced handling of subprocess commands to utilize the cache directory effectively.

- **Refactor**
	- Updated method signatures to include an optional `cache_dir` parameter in relevant methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->